### PR TITLE
fix: actions: lint_push: `ERR_PNPM_NO_LOCKFILE`

### DIFF
--- a/.github/workflows/test_lint.yml
+++ b/.github/workflows/test_lint.yml
@@ -9,17 +9,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22.18.0
-          cache: 'pnpm'
-
+      # pnpm should be pre-installed to use cache in actions/setup-node@v4
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
           version: 10
           run_install: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.18.0
+          cache: 'pnpm'
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
### Why

`Run pnpm install --frozen-lockfile` fails with `ERR_PNPM_NO_LOCKFILE  Cannot install with "frozen-lockfile" because pnpm-lock.yaml is absent`

<details>
<summary>Show full log</summary>

```
2025-08-18T15:38:03.0081586Z Current runner version: '2.327.1'
2025-08-18T15:38:03.0105403Z ##[group]Runner Image Provisioner
2025-08-18T15:38:03.0106283Z Hosted Compute Agent
2025-08-18T15:38:03.0106812Z Version: 20250818.377
2025-08-18T15:38:03.0107412Z Commit: 3c593e9f75fe0b87e893bca80d6e12ba089c61fc
2025-08-18T15:38:03.0108103Z Build Date: 2025-08-18T14:52:18Z
2025-08-18T15:38:03.0108906Z ##[endgroup]
2025-08-18T15:38:03.0109436Z ##[group]Operating System
2025-08-18T15:38:03.0110044Z Ubuntu
2025-08-18T15:38:03.0110505Z 24.04.2
2025-08-18T15:38:03.0110980Z LTS
2025-08-18T15:38:03.0111398Z ##[endgroup]
2025-08-18T15:38:03.0111951Z ##[group]Runner Image
2025-08-18T15:38:03.0112526Z Image: ubuntu-24.04
2025-08-18T15:38:03.0113004Z Version: 20250810.1.0
2025-08-18T15:38:03.0114082Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20250810.1/images/ubuntu/Ubuntu2404-Readme.md
2025-08-18T15:38:03.0115590Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20250810.1
2025-08-18T15:38:03.0116595Z ##[endgroup]
2025-08-18T15:38:03.0117691Z ##[group]GITHUB_TOKEN Permissions
2025-08-18T15:38:03.0120136Z Contents: read
2025-08-18T15:38:03.0120689Z Metadata: read
2025-08-18T15:38:03.0121154Z Packages: read
2025-08-18T15:38:03.0121743Z ##[endgroup]
2025-08-18T15:38:03.0123755Z Secret source: Actions
2025-08-18T15:38:03.0124875Z Prepare workflow directory
2025-08-18T15:38:03.0448105Z Prepare all required actions
2025-08-18T15:38:03.0487160Z Getting action download info
2025-08-18T15:38:03.4687314Z Download action repository 'actions/checkout@v4' (SHA:08eba0b27e820071cde6df949e0beb9ba4906955)
2025-08-18T15:38:04.0731021Z Download action repository 'actions/setup-node@v4' (SHA:49933ea5288caeca8642d1e84afbd3f7d6820020)
2025-08-18T15:38:04.1616075Z Download action repository 'pnpm/action-setup@v3' (SHA:a3252b78c470c02df07e9d59298aecedc3ccdd6d)
2025-08-18T15:38:04.6909884Z Download action repository 'actions/cache@v4' (SHA:0400d5f644dc74513175e3cd8d07132dd4860809)
2025-08-18T15:38:05.3603280Z Complete job name: lint
2025-08-18T15:38:05.4369706Z ##[group]Run actions/checkout@v4
2025-08-18T15:38:05.4370928Z with:
2025-08-18T15:38:05.4371593Z   repository: mgn901/sbullasy
2025-08-18T15:38:05.4372691Z   token: ***
2025-08-18T15:38:05.4373352Z   ssh-strict: true
2025-08-18T15:38:05.4374048Z   ssh-user: git
2025-08-18T15:38:05.4374764Z   persist-credentials: true
2025-08-18T15:38:05.4375575Z   clean: true
2025-08-18T15:38:05.4376303Z   sparse-checkout-cone-mode: true
2025-08-18T15:38:05.4377185Z   fetch-depth: 1
2025-08-18T15:38:05.4377878Z   fetch-tags: false
2025-08-18T15:38:05.4378899Z   show-progress: true
2025-08-18T15:38:05.4379664Z   lfs: false
2025-08-18T15:38:05.4380318Z   submodules: false
2025-08-18T15:38:05.4381048Z   set-safe-directory: true
2025-08-18T15:38:05.4382118Z ##[endgroup]
2025-08-18T15:38:05.5500050Z Syncing repository: mgn901/sbullasy
2025-08-18T15:38:05.5502412Z ##[group]Getting Git version info
2025-08-18T15:38:05.5503636Z Working directory is '/home/runner/work/sbullasy/sbullasy'
2025-08-18T15:38:05.5505426Z [command]/usr/bin/git version
2025-08-18T15:38:05.5569081Z git version 2.50.1
2025-08-18T15:38:05.5595717Z ##[endgroup]
2025-08-18T15:38:05.5609154Z Temporarily overriding HOME='/home/runner/work/_temp/12f92bc7-df5d-4144-bf74-945f45d315a2' before making global git config changes
2025-08-18T15:38:05.5611878Z Adding repository directory to the temporary git global config as a safe directory
2025-08-18T15:38:05.5621415Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/sbullasy/sbullasy
2025-08-18T15:38:05.5656849Z Deleting the contents of '/home/runner/work/sbullasy/sbullasy'
2025-08-18T15:38:05.5660325Z ##[group]Initializing the repository
2025-08-18T15:38:05.5664091Z [command]/usr/bin/git init /home/runner/work/sbullasy/sbullasy
2025-08-18T15:38:05.5770119Z hint: Using 'master' as the name for the initial branch. This default branch name
2025-08-18T15:38:05.5772050Z hint: is subject to change. To configure the initial branch name to use in all
2025-08-18T15:38:05.5774654Z hint: of your new repositories, which will suppress this warning, call:
2025-08-18T15:38:05.5776381Z hint:
2025-08-18T15:38:05.5777811Z hint: 	git config --global init.defaultBranch <name>
2025-08-18T15:38:05.5779821Z hint:
2025-08-18T15:38:05.5781582Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
2025-08-18T15:38:05.5784491Z hint: 'development'. The just-created branch can be renamed via this command:
2025-08-18T15:38:05.5786753Z hint:
2025-08-18T15:38:05.5787910Z hint: 	git branch -m <name>
2025-08-18T15:38:05.5789458Z hint:
2025-08-18T15:38:05.5791272Z hint: Disable this message with "git config set advice.defaultBranchName false"
2025-08-18T15:38:05.5794403Z Initialized empty Git repository in /home/runner/work/sbullasy/sbullasy/.git/
2025-08-18T15:38:05.5797266Z [command]/usr/bin/git remote add origin https://github.com/mgn901/sbullasy
2025-08-18T15:38:05.5824407Z ##[endgroup]
2025-08-18T15:38:05.5826531Z ##[group]Disabling automatic garbage collection
2025-08-18T15:38:05.5828773Z [command]/usr/bin/git config --local gc.auto 0
2025-08-18T15:38:05.5857047Z ##[endgroup]
2025-08-18T15:38:05.5859252Z ##[group]Setting up auth
2025-08-18T15:38:05.5864523Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
2025-08-18T15:38:05.5896589Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
2025-08-18T15:38:05.6228088Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
2025-08-18T15:38:05.6261226Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
2025-08-18T15:38:05.6479300Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
2025-08-18T15:38:05.6514605Z ##[endgroup]
2025-08-18T15:38:05.6516732Z ##[group]Fetching the repository
2025-08-18T15:38:05.6534166Z [command]/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +55b0668337ac89807250e7aad49ed199d40d92ef:refs/remotes/origin/chore/update-deps
2025-08-18T15:38:06.0223988Z From https://github.com/mgn901/sbullasy
2025-08-18T15:38:06.0225576Z  * [new ref]         55b0668337ac89807250e7aad49ed199d40d92ef -> origin/chore/update-deps
2025-08-18T15:38:06.0260917Z ##[endgroup]
2025-08-18T15:38:06.0263597Z ##[group]Determining the checkout info
2025-08-18T15:38:06.0265332Z ##[endgroup]
2025-08-18T15:38:06.0269460Z [command]/usr/bin/git sparse-checkout disable
2025-08-18T15:38:06.0315116Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
2025-08-18T15:38:06.0345490Z ##[group]Checking out the ref
2025-08-18T15:38:06.0349122Z [command]/usr/bin/git checkout --progress --force -B chore/update-deps refs/remotes/origin/chore/update-deps
2025-08-18T15:38:06.0464271Z Switched to a new branch 'chore/update-deps'
2025-08-18T15:38:06.0468117Z branch 'chore/update-deps' set up to track 'origin/chore/update-deps'.
2025-08-18T15:38:06.0479227Z ##[endgroup]
2025-08-18T15:38:06.0513940Z [command]/usr/bin/git log -1 --format=%H
2025-08-18T15:38:06.0538072Z 55b0668337ac89807250e7aad49ed199d40d92ef
2025-08-18T15:38:06.0820120Z ##[group]Run actions/setup-node@v4
2025-08-18T15:38:06.0820826Z with:
2025-08-18T15:38:06.0821400Z   node-version: 21.7.1
2025-08-18T15:38:06.0822013Z   always-auth: false
2025-08-18T15:38:06.0822610Z   check-latest: false
2025-08-18T15:38:06.0823370Z   token: ***
2025-08-18T15:38:06.0823949Z ##[endgroup]
2025-08-18T15:38:06.2521665Z Attempting to download 21.7.1...
2025-08-18T15:38:06.8283113Z Not found in manifest. Falling back to download directly from Node
2025-08-18T15:38:07.0189743Z Acquiring 21.7.1 - x64 from https://nodejs.org/dist/v21.7.1/node-v21.7.1-linux-x64.tar.gz
2025-08-18T15:38:07.9535792Z Extracting ...
2025-08-18T15:38:07.9639405Z [command]/usr/bin/tar xz --strip 1 --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/fe4d8602-d167-4c50-a1ea-9cfbc75cd631 -f /home/runner/work/_temp/239e5550-e6b5-48b7-9600-7c06985feffe
2025-08-18T15:38:08.9726050Z Adding to the cache ...
2025-08-18T15:38:11.0420402Z Done
2025-08-18T15:38:11.0424815Z ##[group]Environment details
2025-08-18T15:38:11.2944828Z node: v21.7.1
2025-08-18T15:38:11.2945224Z npm: 10.5.0
2025-08-18T15:38:11.2945528Z yarn: 1.22.22
2025-08-18T15:38:11.2946235Z ##[endgroup]
2025-08-18T15:38:11.3114396Z ##[group]Run pnpm/action-setup@v3
2025-08-18T15:38:11.3114664Z with:
2025-08-18T15:38:11.3114841Z   version: 8
2025-08-18T15:38:11.3115019Z   run_install: false
2025-08-18T15:38:11.3115224Z   dest: ~/setup-pnpm
2025-08-18T15:38:11.3115457Z   package_json_file: package.json
2025-08-18T15:38:11.3115707Z   standalone: false
2025-08-18T15:38:11.3115906Z ##[endgroup]
2025-08-18T15:38:11.3965916Z ##[group]Running self-installer...
2025-08-18T15:38:12.0090949Z Progress: resolved 1, reused 0, downloaded 0, added 0
2025-08-18T15:38:12.0279818Z Packages: +1
2025-08-18T15:38:12.0299574Z +
2025-08-18T15:38:12.4084115Z Progress: resolved 1, reused 0, downloaded 1, added 1, done
2025-08-18T15:38:12.4364088Z 
2025-08-18T15:38:12.4364768Z dependencies:
2025-08-18T15:38:12.4365329Z + pnpm 8.15.9 (10.14.0 is available)
2025-08-18T15:38:12.4365774Z 
2025-08-18T15:38:12.4399672Z Done in 878ms
2025-08-18T15:38:12.4580063Z ##[endgroup]
2025-08-18T15:38:12.4584165Z Installation Completed!
2025-08-18T15:38:12.4678194Z ##[group]Run echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
2025-08-18T15:38:12.4679180Z [36;1mecho "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV[0m
2025-08-18T15:38:12.4758263Z shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
2025-08-18T15:38:12.4758847Z env:
2025-08-18T15:38:12.4759087Z   PNPM_HOME: /home/runner/setup-pnpm/node_modules/.bin
2025-08-18T15:38:12.4759378Z ##[endgroup]
2025-08-18T15:38:12.9635573Z ##[group]Run actions/cache@v4
2025-08-18T15:38:12.9635853Z with:
2025-08-18T15:38:12.9636099Z   path: /home/runner/setup-pnpm/node_modules/.bin/store/v3
2025-08-18T15:38:12.9636587Z   key: Linux-pnpm-store-27f6d9de92accf696125a17df9ed11a624355b7f92b12a08d08aa3a6f376e3df
2025-08-18T15:38:12.9637045Z   restore-keys: Linux-pnpm-store-

2025-08-18T15:38:12.9637302Z   enableCrossOsArchive: false
2025-08-18T15:38:12.9637534Z   fail-on-cache-miss: false
2025-08-18T15:38:12.9637749Z   lookup-only: false
2025-08-18T15:38:12.9637943Z   save-always: false
2025-08-18T15:38:12.9638116Z env:
2025-08-18T15:38:12.9638332Z   PNPM_HOME: /home/runner/setup-pnpm/node_modules/.bin
2025-08-18T15:38:12.9639154Z   STORE_PATH: /home/runner/setup-pnpm/node_modules/.bin/store/v3
2025-08-18T15:38:12.9639458Z ##[endgroup]
2025-08-18T15:38:13.2696171Z Cache not found for input keys: Linux-pnpm-store-27f6d9de92accf696125a17df9ed11a624355b7f92b12a08d08aa3a6f376e3df, Linux-pnpm-store-
2025-08-18T15:38:13.2765624Z ##[group]Run pnpm install --frozen-lockfile
2025-08-18T15:38:13.2765998Z [36;1mpnpm install --frozen-lockfile[0m
2025-08-18T15:38:13.2806319Z shell: /usr/bin/bash -e {0}
2025-08-18T15:38:13.2806552Z env:
2025-08-18T15:38:13.2806785Z   PNPM_HOME: /home/runner/setup-pnpm/node_modules/.bin
2025-08-18T15:38:13.2807158Z   STORE_PATH: /home/runner/setup-pnpm/node_modules/.bin/store/v3
2025-08-18T15:38:13.2807479Z ##[endgroup]
2025-08-18T15:38:13.7180818Z  WARN  Ignoring not compatible lockfile at /home/runner/work/sbullasy/sbullasy/pnpm-lock.yaml
2025-08-18T15:38:13.7205330Z  ERR_PNPM_NO_LOCKFILE  Cannot install with "frozen-lockfile" because pnpm-lock.yaml is absent
2025-08-18T15:38:13.7206023Z 
2025-08-18T15:38:13.7206873Z Note that in CI environments this setting is true by default. If you still need to run install in such cases, use "pnpm install --no-frozen-lockfile"
2025-08-18T15:38:13.7417660Z ##[error]Process completed with exit code 1.
2025-08-18T15:38:13.7478393Z Post job cleanup.
2025-08-18T15:38:13.8325722Z Pruning is unnecessary.
2025-08-18T15:38:13.8431106Z Post job cleanup.
2025-08-18T15:38:13.9400147Z [command]/usr/bin/git version
2025-08-18T15:38:13.9435541Z git version 2.50.1
2025-08-18T15:38:13.9479402Z Temporarily overriding HOME='/home/runner/work/_temp/8f966b0c-1f01-4057-95af-6292bbf65a8a' before making global git config changes
2025-08-18T15:38:13.9480984Z Adding repository directory to the temporary git global config as a safe directory
2025-08-18T15:38:13.9492610Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/sbullasy/sbullasy
2025-08-18T15:38:13.9526729Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
2025-08-18T15:38:13.9559104Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
2025-08-18T15:38:13.9783454Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
2025-08-18T15:38:13.9803806Z http.https://github.com/.extraheader
2025-08-18T15:38:13.9816132Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
2025-08-18T15:38:13.9845986Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
2025-08-18T15:38:14.0164246Z Cleaning up orphan processes
```

</details>

### What's changed

- update node-version
- update pnpm version
- use cache provided by actions/setup-node@v4
- pnpm should be pre-installed to use cache in `actions/setup-node@v4`